### PR TITLE
Update wheel params

### DIFF
--- a/loki_bringup/param/loki.yaml
+++ b/loki_bringup/param/loki.yaml
@@ -22,8 +22,8 @@ poll_rate: 25
 base_frame: base_link
 
 # === Robot drivetrain parameters
-wheel_diameter: 0.060
-wheel_track: 0.132
+wheel_diameter: 0.065
+wheel_spread: 0.15
 encoder_resolution: 3560
 gear_reduction: 1.0
 


### PR DESCRIPTION
Updated wheel diameter and spread by measuring them and then adjusting empirically until moving forward 1 meter and rotating 90 degrees were accurate.  `loki_base_node/bus_server.py` uses `wheel_spread`, not `wheel_track`, which was previously in `params.yaml`